### PR TITLE
Remove bottom border on .d-header

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -679,7 +679,6 @@ p.footer-donation {
 .d-header {
   height: $--global-nav-height;
   background-color: $--gray85;
-  border-bottom: 1px solid $--gray75;
   box-shadow: none;
   position: fixed;
   margin-top: #{$--global-nav-height * 2};


### PR DESCRIPTION
I would have created an issue first, but there is no option for that :sweat_smile:
I am not even sure if this is the correct repository.

On [https://www.freecodecamp.org/forum/](https://www.freecodecamp.org/forum/),
In the light theme, the border-bottom looks weird on hovering over any of the menu items.
Image for reference: [https://imgur.com/oUvjR8T](https://imgur.com/oUvjR8T)
Removing the border makes it look seamless on `Light`, `Dawn` as well as `Dark` theme.